### PR TITLE
Move local and memory to separate exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/file-storage.js",
+    "./local": "./dist/local.js",
+    "./memory": "./dist/memory.js",
     "./package.json": "./package.json"
   },
   "devDependencies": {

--- a/src/file-storage.ts
+++ b/src/file-storage.ts
@@ -1,3 +1,1 @@
 export { type FileStorage } from "./lib/file-storage.js";
-export { LocalFileStorage } from "./lib/local-file-storage.js";
-export { MemoryFileStorage } from "./lib/memory-file-storage.js";

--- a/src/local.ts
+++ b/src/local.ts
@@ -1,0 +1,1 @@
+export { LocalFileStorage } from "./lib/local-file-storage.js";

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,1 @@
+export { MemoryFileStorage } from "./lib/memory-file-storage.js";


### PR DESCRIPTION
Instead of exporting LocalFileStorage and MemoryFileStorage from the main export, they could be moved to named ones.

So you go from:

```ts
import {
  type FileStorage,
  LocalFileStorage,
  MemoryFileStorage
} from "@mjackson/file-storage";
```

To:

```ts
import type { FileStorage } from "@mjackson/file-storage";
import { LocaleFileStorage } from "@mjackson/file-storage/local":
import { MemoryFileStorage } from "@mjackson/file-storage/memory":
```

The main advantage is that unless you import from `@mjackson/file-storage/local` you're sure you won't get any `node:` module, which should help ensure this package works in Cloudflare without issues.

Another benefit is that a `@mjackson/file-storage/r2` could be added later and using optional peer dependencies, this separate module could need the installation of `@cloudflare/worker-types` without being required if you use the memory or locale one.